### PR TITLE
Added filters for quote searching endpoint

### DIFF
--- a/src/app/api/authors/route.ts
+++ b/src/app/api/authors/route.ts
@@ -3,6 +3,7 @@ import { Database } from "@/utilities/database";
 
 const DEFAULT_OFFSET = 0;
 const DEFAULT_LIMIT = 10;
+const MAX_LIMIT = 100;
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
@@ -11,7 +12,7 @@ export async function GET(request: NextRequest) {
     searchParams.get("offset") ?? `${DEFAULT_OFFSET}`,
     10
   );
-  const parsed_limit = parseInt(
+  let parsed_limit = parseInt(
     searchParams.get("limit") ?? `${DEFAULT_LIMIT}`,
     10
   );
@@ -25,6 +26,10 @@ export async function GET(request: NextRequest) {
   }
 
   if (errors.length > 0) return NextResponse.json({ errors }, { status: 400 });
+
+  if (parsed_limit > MAX_LIMIT) {
+    parsed_limit = MAX_LIMIT;
+  }
 
   const db = new Database();
   const [quotes, count] = await Promise.all([

--- a/src/app/api/quotes/route.ts
+++ b/src/app/api/quotes/route.ts
@@ -4,6 +4,15 @@ import { Database } from "@/utilities/database";
 const DEFAULT_OFFSET = 0;
 const DEFAULT_LIMIT = 10;
 
+const MAX_LIMIT = 100;
+
+const ensureNumber = (value: string | null | undefined) => {
+  if (value === undefined || value === null) return undefined;
+  const parsed = parseInt(value, 10);
+  if (isNaN(parsed)) return undefined;
+  return parsed;
+};
+
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
 
@@ -11,12 +20,14 @@ export async function GET(request: NextRequest) {
     searchParams.get("offset") ?? `${DEFAULT_OFFSET}`,
     10
   );
-  const parsed_limit = parseInt(
+  let parsed_limit = parseInt(
     searchParams.get("limit") ?? `${DEFAULT_LIMIT}`,
     10
   );
+  const parsed_author_id = ensureNumber(searchParams.get("author_id"));
 
   let errors = [];
+
   if (isNaN(parsed_offset)) {
     errors.push("offset must be a number");
   }
@@ -26,13 +37,24 @@ export async function GET(request: NextRequest) {
 
   if (errors.length > 0) return NextResponse.json({ errors }, { status: 400 });
 
+  if (parsed_limit > MAX_LIMIT) {
+    parsed_limit = MAX_LIMIT;
+  }
+
+  const filters = {
+    author_id: parsed_author_id,
+  };
+
   const db = new Database();
   const [quotes, count] = await Promise.all([
     db.findQuotes({
+      filters,
       offset: isNaN(parsed_offset) ? undefined : parsed_offset,
       limit: isNaN(parsed_limit) ? undefined : parsed_limit,
     }),
-    db.countQuotes({}),
+    db.countQuotes({
+      filters,
+    }),
   ]);
 
   return NextResponse.json({

--- a/src/utilities/database.ts
+++ b/src/utilities/database.ts
@@ -146,23 +146,50 @@ export class Database {
   }
 
   async findQuotes({
+    filters,
     offset,
     limit,
   }: {
+    filters?: {
+      author_id?: number;
+    };
     offset?: number;
     limit?: number;
   }): Promise<QuoteWithAuthor[]> {
+    const conditions = ["is_active=1"];
+    const conditionsValues = [];
+    if (filters?.author_id) {
+      conditions.push("quotes.author_id=?");
+      conditionsValues.push(filters.author_id);
+    }
+
     const results = await this.connection.execute(
-      `${select} ${from} WHERE is_active=1 LIMIT ? OFFSET ?`,
-      [limit, offset]
+      `${select} ${from} WHERE ${conditions.join(" AND ")} LIMIT ? OFFSET ?`,
+      [...conditionsValues, limit, offset]
     );
 
     return results.rows as QuoteWithAuthor[];
   }
 
-  async countQuotes({}: {}): Promise<number> {
+  async countQuotes({
+    filters,
+  }: {
+    filters?: {
+      author_id?: number;
+    };
+  }): Promise<number> {
+    const conditions = ["is_active=1"];
+    const conditionsValues = [];
+    if (filters?.author_id) {
+      conditions.push("quotes.author_id=?");
+      conditionsValues.push(filters.author_id);
+    }
+
     const results = await this.connection.execute(
-      `SELECT COUNT(id) as count FROM quotes WHERE is_active=1`
+      `SELECT COUNT(id) as count FROM quotes WHERE ${conditions.join(
+        " AND "
+      )} `,
+      [...conditionsValues]
     );
     return extractCount(results);
   }


### PR DESCRIPTION
Added filter option for GET `/api/quotes`

if you send author_id in the query param the api will only return results for that author now

the total count will also only be for that author