### PR TITLE
Add Teal Blossom theme

### DIFF
--- a/src/app/common.ts
+++ b/src/app/common.ts
@@ -18,6 +18,7 @@ export enum ColorScheme {
   GoldenEarth = "golden-earth",
   PaleSerenity = "pale-serenity",
   RetroHour = "retro-hour",
+  TealBlossom = "teal-blossom",
 }
 
 export enum ImagePresets {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -142,6 +142,12 @@
     --color-primary: #f2d7d9;
     --color-secondary: #748da6;
   }
+  [data-theme="teal-blossom"] {
+    --color-background: #d7f7f5;
+    --color-accent: #75cac3;
+    --color-primary: #2a6171;
+    --color-secondary: #f34573;
+  }
 }
 
 .grecaptcha-badge {

--- a/src/hooks/useColorScheme.ts
+++ b/src/hooks/useColorScheme.ts
@@ -30,6 +30,7 @@ function validateColorScheme(colorScheme: string): colorScheme is ColorScheme {
     colorScheme === ColorScheme.GoldenEarth ||
     colorScheme === ColorScheme.PaleSerenity ||
     colorScheme === ColorScheme.RetroHour ||
+    colorScheme === ColorScheme.TealBlossom ||
     colorScheme === ColorScheme.System
   );
 }


### PR DESCRIPTION
## Summary
Adds a new "Teal Blossom" theme with colors extracted from the ColorHunt palette. The theme features a light mint background, medium teal accent, dark teal primary text, and a vibrant pink secondary accent.

## Changes
- Added `TealBlossom` to the `ColorScheme` enum
- Updated `validateColorScheme` function to include the new theme
- Added CSS theme variables for the Teal Blossom color scheme

🤖 Generated with Claude Code