### PR TITLE
Add Midnight Orchid theme from ColorHunt palette

### DIFF
--- a/src/app/common.ts
+++ b/src/app/common.ts
@@ -20,6 +20,7 @@ export enum ColorScheme {
   RetroHour = "retro-hour",
   TealBlossom = "teal-blossom",
   MeadowGlow = "meadow-glow",
+  MidnightOrchid = "midnight-orchid",
 }
 
 export enum ImagePresets {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -154,6 +154,12 @@
     --color-primary: #7a4a20;
     --color-secondary: #ffbf86;
   }
+  [data-theme="midnight-orchid"] {
+    --color-background: #470938;
+    --color-accent: #1a3e59;
+    --color-primary: #f2d6eb;
+    --color-secondary: #5c94bd;
+  }
 }
 
 .grecaptcha-badge {

--- a/src/hooks/useColorScheme.ts
+++ b/src/hooks/useColorScheme.ts
@@ -32,6 +32,7 @@ function validateColorScheme(colorScheme: string): colorScheme is ColorScheme {
     colorScheme === ColorScheme.RetroHour ||
     colorScheme === ColorScheme.TealBlossom ||
     colorScheme === ColorScheme.MeadowGlow ||
+    colorScheme === ColorScheme.MidnightOrchid ||
     colorScheme === ColorScheme.System
   );
 }


### PR DESCRIPTION
## Summary
Adds the Midnight Orchid theme with a deep purple background (#470938), dark navy accents (#1a3e59), soft pink primary text (#f2d6eb), and steel blue secondary elements (#5c94bd). The palette creates a rich, nocturnal aesthetic inspired by a ColorHunt design.

## Changes
- Added `MidnightOrchid` to the ColorScheme enum
- Added theme CSS variables to globals.css
- Updated color scheme validation in useColorScheme hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)