### PR TITLE
Add Aqua Glow theme from ColorHunt palette

### DIFF
--- a/src/app/common.ts
+++ b/src/app/common.ts
@@ -27,6 +27,33 @@ export enum ColorScheme {
   CobaltEmber = "cobalt-ember",
   EmberDune = "ember-dune",
   AquaGlow = "aqua-glow",
+  // Aqua Glow palette — white background variants
+  AquaCitrus = "aqua-citrus",
+  CrystalTeal = "crystal-teal",
+  CrystalLemon = "crystal-lemon",
+  FrostSaffron = "frost-saffron",
+  WhiteSaffron = "white-saffron",
+  // Aqua Glow palette — light teal background variants
+  FoamGlow = "foam-glow",
+  FoamCitrus = "foam-citrus",
+  SeafoamWhite = "seafoam-white",
+  SeafoamGlow = "seafoam-glow",
+  TealLemon = "teal-lemon",
+  TealDew = "teal-dew",
+  // Aqua Glow palette — medium teal background variants
+  DeepFoam = "deep-foam",
+  DeepCitrus = "deep-citrus",
+  OceanFrost = "ocean-frost",
+  OceanGlow = "ocean-glow",
+  TealSaffron = "teal-saffron",
+  TealHarvest = "teal-harvest",
+  // Aqua Glow palette — yellow background variants
+  SunnyFrost = "sunny-frost",
+  GoldenFrost = "golden-frost",
+  LemonFoam = "lemon-foam",
+  LemonTeal = "lemon-teal",
+  GoldenTeal = "golden-teal",
+  SunnyTeal = "sunny-teal",
 }
 
 export enum ImagePresets {

--- a/src/app/common.ts
+++ b/src/app/common.ts
@@ -26,34 +26,7 @@ export enum ColorScheme {
   SteelAmber = "steel-amber",
   CobaltEmber = "cobalt-ember",
   EmberDune = "ember-dune",
-  AquaGlow = "aqua-glow",
-  // Aqua Glow palette — white background variants
-  AquaCitrus = "aqua-citrus",
-  CrystalTeal = "crystal-teal",
-  CrystalLemon = "crystal-lemon",
-  FrostSaffron = "frost-saffron",
-  WhiteSaffron = "white-saffron",
-  // Aqua Glow palette — light teal background variants
-  FoamGlow = "foam-glow",
-  FoamCitrus = "foam-citrus",
-  SeafoamWhite = "seafoam-white",
-  SeafoamGlow = "seafoam-glow",
-  TealLemon = "teal-lemon",
-  TealDew = "teal-dew",
-  // Aqua Glow palette — medium teal background variants
-  DeepFoam = "deep-foam",
-  DeepCitrus = "deep-citrus",
-  OceanFrost = "ocean-frost",
   OceanGlow = "ocean-glow",
-  TealSaffron = "teal-saffron",
-  TealHarvest = "teal-harvest",
-  // Aqua Glow palette — yellow background variants
-  SunnyFrost = "sunny-frost",
-  GoldenFrost = "golden-frost",
-  LemonFoam = "lemon-foam",
-  LemonTeal = "lemon-teal",
-  GoldenTeal = "golden-teal",
-  SunnyTeal = "sunny-teal",
 }
 
 export enum ImagePresets {

--- a/src/app/common.ts
+++ b/src/app/common.ts
@@ -26,6 +26,7 @@ export enum ColorScheme {
   SteelAmber = "steel-amber",
   CobaltEmber = "cobalt-ember",
   EmberDune = "ember-dune",
+  AquaGlow = "aqua-glow",
 }
 
 export enum ImagePresets {

--- a/src/app/themes.ts
+++ b/src/app/themes.ts
@@ -33,6 +33,33 @@ export const themes: Record<string, ThemeColors> = {
   "cobalt-ember": { background: "#125d98", accent: "#3c8dad", primary: "#f5a962", secondary: "#dddddd" },
   "ember-dune": { background: "#bb6464", accent: "#c3dbd9", primary: "#cdb699", secondary: "#c8f2ef" },
   "aqua-glow": { background: "#f9fbfc", accent: "#a0dbdb", primary: "#56a7a7", secondary: "#fcea90" },
+  // White background variants
+  "aqua-citrus":   { background: "#f9fbfc", accent: "#a0dbdb", primary: "#fcea90", secondary: "#56a7a7" },
+  "crystal-teal":  { background: "#f9fbfc", accent: "#56a7a7", primary: "#a0dbdb", secondary: "#fcea90" },
+  "crystal-lemon": { background: "#f9fbfc", accent: "#56a7a7", primary: "#fcea90", secondary: "#a0dbdb" },
+  "frost-saffron": { background: "#f9fbfc", accent: "#fcea90", primary: "#a0dbdb", secondary: "#56a7a7" },
+  "white-saffron": { background: "#f9fbfc", accent: "#fcea90", primary: "#56a7a7", secondary: "#a0dbdb" },
+  // Light teal background variants
+  "foam-glow":     { background: "#a0dbdb", accent: "#f9fbfc", primary: "#56a7a7", secondary: "#fcea90" },
+  "foam-citrus":   { background: "#a0dbdb", accent: "#f9fbfc", primary: "#fcea90", secondary: "#56a7a7" },
+  "seafoam-white": { background: "#a0dbdb", accent: "#56a7a7", primary: "#f9fbfc", secondary: "#fcea90" },
+  "seafoam-glow":  { background: "#a0dbdb", accent: "#56a7a7", primary: "#fcea90", secondary: "#f9fbfc" },
+  "teal-lemon":    { background: "#a0dbdb", accent: "#fcea90", primary: "#f9fbfc", secondary: "#56a7a7" },
+  "teal-dew":      { background: "#a0dbdb", accent: "#fcea90", primary: "#56a7a7", secondary: "#f9fbfc" },
+  // Medium teal background variants
+  "deep-foam":     { background: "#56a7a7", accent: "#f9fbfc", primary: "#a0dbdb", secondary: "#fcea90" },
+  "deep-citrus":   { background: "#56a7a7", accent: "#f9fbfc", primary: "#fcea90", secondary: "#a0dbdb" },
+  "ocean-frost":   { background: "#56a7a7", accent: "#a0dbdb", primary: "#f9fbfc", secondary: "#fcea90" },
+  "ocean-glow":    { background: "#56a7a7", accent: "#a0dbdb", primary: "#fcea90", secondary: "#f9fbfc" },
+  "teal-saffron":  { background: "#56a7a7", accent: "#fcea90", primary: "#f9fbfc", secondary: "#a0dbdb" },
+  "teal-harvest":  { background: "#56a7a7", accent: "#fcea90", primary: "#a0dbdb", secondary: "#f9fbfc" },
+  // Yellow background variants
+  "sunny-frost":   { background: "#fcea90", accent: "#f9fbfc", primary: "#a0dbdb", secondary: "#56a7a7" },
+  "golden-frost":  { background: "#fcea90", accent: "#f9fbfc", primary: "#56a7a7", secondary: "#a0dbdb" },
+  "lemon-foam":    { background: "#fcea90", accent: "#a0dbdb", primary: "#f9fbfc", secondary: "#56a7a7" },
+  "lemon-teal":    { background: "#fcea90", accent: "#a0dbdb", primary: "#56a7a7", secondary: "#f9fbfc" },
+  "golden-teal":   { background: "#fcea90", accent: "#56a7a7", primary: "#f9fbfc", secondary: "#a0dbdb" },
+  "sunny-teal":    { background: "#fcea90", accent: "#56a7a7", primary: "#a0dbdb", secondary: "#f9fbfc" },
 };
 
 export function generateThemeCSS(): string {

--- a/src/app/themes.ts
+++ b/src/app/themes.ts
@@ -32,34 +32,7 @@ export const themes: Record<string, ThemeColors> = {
   "steel-amber": { background: "#dddddd", accent: "#3c8dad", primary: "#125d98", secondary: "#f5a962" },
   "cobalt-ember": { background: "#125d98", accent: "#3c8dad", primary: "#f5a962", secondary: "#dddddd" },
   "ember-dune": { background: "#bb6464", accent: "#c3dbd9", primary: "#cdb699", secondary: "#c8f2ef" },
-  "aqua-glow": { background: "#f9fbfc", accent: "#a0dbdb", primary: "#56a7a7", secondary: "#fcea90" },
-  // White background variants
-  "aqua-citrus":   { background: "#f9fbfc", accent: "#a0dbdb", primary: "#fcea90", secondary: "#56a7a7" },
-  "crystal-teal":  { background: "#f9fbfc", accent: "#56a7a7", primary: "#a0dbdb", secondary: "#fcea90" },
-  "crystal-lemon": { background: "#f9fbfc", accent: "#56a7a7", primary: "#fcea90", secondary: "#a0dbdb" },
-  "frost-saffron": { background: "#f9fbfc", accent: "#fcea90", primary: "#a0dbdb", secondary: "#56a7a7" },
-  "white-saffron": { background: "#f9fbfc", accent: "#fcea90", primary: "#56a7a7", secondary: "#a0dbdb" },
-  // Light teal background variants
-  "foam-glow":     { background: "#a0dbdb", accent: "#f9fbfc", primary: "#56a7a7", secondary: "#fcea90" },
-  "foam-citrus":   { background: "#a0dbdb", accent: "#f9fbfc", primary: "#fcea90", secondary: "#56a7a7" },
-  "seafoam-white": { background: "#a0dbdb", accent: "#56a7a7", primary: "#f9fbfc", secondary: "#fcea90" },
-  "seafoam-glow":  { background: "#a0dbdb", accent: "#56a7a7", primary: "#fcea90", secondary: "#f9fbfc" },
-  "teal-lemon":    { background: "#a0dbdb", accent: "#fcea90", primary: "#f9fbfc", secondary: "#56a7a7" },
-  "teal-dew":      { background: "#a0dbdb", accent: "#fcea90", primary: "#56a7a7", secondary: "#f9fbfc" },
-  // Medium teal background variants
-  "deep-foam":     { background: "#56a7a7", accent: "#f9fbfc", primary: "#a0dbdb", secondary: "#fcea90" },
-  "deep-citrus":   { background: "#56a7a7", accent: "#f9fbfc", primary: "#fcea90", secondary: "#a0dbdb" },
-  "ocean-frost":   { background: "#56a7a7", accent: "#a0dbdb", primary: "#f9fbfc", secondary: "#fcea90" },
-  "ocean-glow":    { background: "#56a7a7", accent: "#a0dbdb", primary: "#fcea90", secondary: "#f9fbfc" },
-  "teal-saffron":  { background: "#56a7a7", accent: "#fcea90", primary: "#f9fbfc", secondary: "#a0dbdb" },
-  "teal-harvest":  { background: "#56a7a7", accent: "#fcea90", primary: "#a0dbdb", secondary: "#f9fbfc" },
-  // Yellow background variants
-  "sunny-frost":   { background: "#fcea90", accent: "#f9fbfc", primary: "#a0dbdb", secondary: "#56a7a7" },
-  "golden-frost":  { background: "#fcea90", accent: "#f9fbfc", primary: "#56a7a7", secondary: "#a0dbdb" },
-  "lemon-foam":    { background: "#fcea90", accent: "#a0dbdb", primary: "#f9fbfc", secondary: "#56a7a7" },
-  "lemon-teal":    { background: "#fcea90", accent: "#a0dbdb", primary: "#56a7a7", secondary: "#f9fbfc" },
-  "golden-teal":   { background: "#fcea90", accent: "#56a7a7", primary: "#f9fbfc", secondary: "#a0dbdb" },
-  "sunny-teal":    { background: "#fcea90", accent: "#56a7a7", primary: "#a0dbdb", secondary: "#f9fbfc" },
+  "ocean-glow":  { background: "#56a7a7", accent: "#a0dbdb", primary: "#fcea90", secondary: "#f9fbfc" },
 };
 
 export function generateThemeCSS(): string {

--- a/src/app/themes.ts
+++ b/src/app/themes.ts
@@ -32,6 +32,7 @@ export const themes: Record<string, ThemeColors> = {
   "steel-amber": { background: "#dddddd", accent: "#3c8dad", primary: "#125d98", secondary: "#f5a962" },
   "cobalt-ember": { background: "#125d98", accent: "#3c8dad", primary: "#f5a962", secondary: "#dddddd" },
   "ember-dune": { background: "#bb6464", accent: "#c3dbd9", primary: "#cdb699", secondary: "#c8f2ef" },
+  "aqua-glow": { background: "#f9fbfc", accent: "#a0dbdb", primary: "#56a7a7", secondary: "#fcea90" },
 };
 
 export function generateThemeCSS(): string {

--- a/src/hooks/useColorScheme.ts
+++ b/src/hooks/useColorScheme.ts
@@ -38,6 +38,29 @@ function validateColorScheme(colorScheme: string): colorScheme is ColorScheme {
     colorScheme === ColorScheme.CobaltEmber ||
     colorScheme === ColorScheme.EmberDune ||
     colorScheme === ColorScheme.AquaGlow ||
+    colorScheme === ColorScheme.AquaCitrus ||
+    colorScheme === ColorScheme.CrystalTeal ||
+    colorScheme === ColorScheme.CrystalLemon ||
+    colorScheme === ColorScheme.FrostSaffron ||
+    colorScheme === ColorScheme.WhiteSaffron ||
+    colorScheme === ColorScheme.FoamGlow ||
+    colorScheme === ColorScheme.FoamCitrus ||
+    colorScheme === ColorScheme.SeafoamWhite ||
+    colorScheme === ColorScheme.SeafoamGlow ||
+    colorScheme === ColorScheme.TealLemon ||
+    colorScheme === ColorScheme.TealDew ||
+    colorScheme === ColorScheme.DeepFoam ||
+    colorScheme === ColorScheme.DeepCitrus ||
+    colorScheme === ColorScheme.OceanFrost ||
+    colorScheme === ColorScheme.OceanGlow ||
+    colorScheme === ColorScheme.TealSaffron ||
+    colorScheme === ColorScheme.TealHarvest ||
+    colorScheme === ColorScheme.SunnyFrost ||
+    colorScheme === ColorScheme.GoldenFrost ||
+    colorScheme === ColorScheme.LemonFoam ||
+    colorScheme === ColorScheme.LemonTeal ||
+    colorScheme === ColorScheme.GoldenTeal ||
+    colorScheme === ColorScheme.SunnyTeal ||
     colorScheme === ColorScheme.System
   );
 }

--- a/src/hooks/useColorScheme.ts
+++ b/src/hooks/useColorScheme.ts
@@ -37,30 +37,7 @@ function validateColorScheme(colorScheme: string): colorScheme is ColorScheme {
     colorScheme === ColorScheme.SteelAmber ||
     colorScheme === ColorScheme.CobaltEmber ||
     colorScheme === ColorScheme.EmberDune ||
-    colorScheme === ColorScheme.AquaGlow ||
-    colorScheme === ColorScheme.AquaCitrus ||
-    colorScheme === ColorScheme.CrystalTeal ||
-    colorScheme === ColorScheme.CrystalLemon ||
-    colorScheme === ColorScheme.FrostSaffron ||
-    colorScheme === ColorScheme.WhiteSaffron ||
-    colorScheme === ColorScheme.FoamGlow ||
-    colorScheme === ColorScheme.FoamCitrus ||
-    colorScheme === ColorScheme.SeafoamWhite ||
-    colorScheme === ColorScheme.SeafoamGlow ||
-    colorScheme === ColorScheme.TealLemon ||
-    colorScheme === ColorScheme.TealDew ||
-    colorScheme === ColorScheme.DeepFoam ||
-    colorScheme === ColorScheme.DeepCitrus ||
-    colorScheme === ColorScheme.OceanFrost ||
     colorScheme === ColorScheme.OceanGlow ||
-    colorScheme === ColorScheme.TealSaffron ||
-    colorScheme === ColorScheme.TealHarvest ||
-    colorScheme === ColorScheme.SunnyFrost ||
-    colorScheme === ColorScheme.GoldenFrost ||
-    colorScheme === ColorScheme.LemonFoam ||
-    colorScheme === ColorScheme.LemonTeal ||
-    colorScheme === ColorScheme.GoldenTeal ||
-    colorScheme === ColorScheme.SunnyTeal ||
     colorScheme === ColorScheme.System
   );
 }

--- a/src/hooks/useColorScheme.ts
+++ b/src/hooks/useColorScheme.ts
@@ -37,6 +37,7 @@ function validateColorScheme(colorScheme: string): colorScheme is ColorScheme {
     colorScheme === ColorScheme.SteelAmber ||
     colorScheme === ColorScheme.CobaltEmber ||
     colorScheme === ColorScheme.EmberDune ||
+    colorScheme === ColorScheme.AquaGlow ||
     colorScheme === ColorScheme.System
   );
 }


### PR DESCRIPTION
Adds a new **Aqua Glow** theme sourced from [ColorHunt](https://colorhunt.co/palette/f9fbfca0dbdb56a7a7fcea90). The palette uses a near-white background (`#F9FBFC`), light teal accent (`#A0DBDB`), medium teal primary (`#56A7A7`), and sunny yellow secondary (`#FCEA90`). Updates `ColorScheme` enum, `themes` record, and `validateColorScheme` function across the three standard theme files.