### PR TITLE
Add Sunny Cove theme from ColorHunt palette

### DIFF
--- a/src/app/common.ts
+++ b/src/app/common.ts
@@ -29,6 +29,7 @@ export enum ColorScheme {
   OceanGlow = "ocean-glow",
   DesertHaze = "desert-haze",
   DesertBloom = "desert-bloom",
+  SunnyCove = "sunny-cove",
 }
 
 export enum ImagePresets {

--- a/src/app/common.ts
+++ b/src/app/common.ts
@@ -28,8 +28,7 @@ export enum ColorScheme {
   EmberDune = "ember-dune",
   OceanGlow = "ocean-glow",
   DesertHaze = "desert-haze",
-  DesertBloom = "desert-bloom",
-  SunnyCove = "sunny-cove",
+  ApricotBliss = "apricot-bliss",
 }
 
 export enum ImagePresets {

--- a/src/app/common.ts
+++ b/src/app/common.ts
@@ -28,6 +28,7 @@ export enum ColorScheme {
   EmberDune = "ember-dune",
   OceanGlow = "ocean-glow",
   DesertHaze = "desert-haze",
+  DesertBloom = "desert-bloom",
 }
 
 export enum ImagePresets {

--- a/src/app/themes.ts
+++ b/src/app/themes.ts
@@ -174,6 +174,12 @@ export const themes: Record<string, ThemeColors> = {
     primary: "#e76f2e",
     secondary: "#2fa4d7",
   },
+  "desert-bloom": {
+    background: "#fffde8",
+    accent: "#f7e0a3",
+    primary: "#4c8492",
+    secondary: "#f09c67",
+  },
 };
 
 export function generateThemeCSS(): string {

--- a/src/app/themes.ts
+++ b/src/app/themes.ts
@@ -180,6 +180,12 @@ export const themes: Record<string, ThemeColors> = {
     primary: "#4c8492",
     secondary: "#f09c67",
   },
+  "sunny-cove": {
+    background: "#fffde8",
+    accent: "#f7e0a3",
+    primary: "#4c8492",
+    secondary: "#f09c67",
+  },
 };
 
 export function generateThemeCSS(): string {

--- a/src/app/themes.ts
+++ b/src/app/themes.ts
@@ -174,17 +174,11 @@ export const themes: Record<string, ThemeColors> = {
     primary: "#e76f2e",
     secondary: "#2fa4d7",
   },
-  "desert-bloom": {
-    background: "#fffde8",
+  "apricot-bliss": {
+    background: "#f09c67",
     accent: "#f7e0a3",
-    primary: "#4c8492",
-    secondary: "#f09c67",
-  },
-  "sunny-cove": {
-    background: "#fffde8",
-    accent: "#f7e0a3",
-    primary: "#4c8492",
-    secondary: "#f09c67",
+    primary: "#fffde8",
+    secondary: "#4c8492",
   },
 };
 

--- a/src/hooks/useColorScheme.ts
+++ b/src/hooks/useColorScheme.ts
@@ -39,6 +39,7 @@ function validateColorScheme(colorScheme: string): colorScheme is ColorScheme {
     colorScheme === ColorScheme.EmberDune ||
     colorScheme === ColorScheme.OceanGlow ||
     colorScheme === ColorScheme.DesertHaze ||
+    colorScheme === ColorScheme.DesertBloom ||
     colorScheme === ColorScheme.System
   );
 }
@@ -70,11 +71,11 @@ function clearBodyClass() {
 }
 
 export function useColorScheme(
-  initialValue: ColorScheme | null
+  initialValue: ColorScheme | null,
 ): UseDarkModeOutput {
   const isDarkOS = useMediaQuery(COLOR_SCHEME_QUERY);
   const [colorScheme, setColorScheme] = React.useState<ColorScheme>(() =>
-    getIntialColorScheme({ initialValue, isDarkOS })
+    getIntialColorScheme({ initialValue, isDarkOS }),
   );
 
   // Update darkMode if os prefers changes

--- a/src/hooks/useColorScheme.ts
+++ b/src/hooks/useColorScheme.ts
@@ -39,8 +39,7 @@ function validateColorScheme(colorScheme: string): colorScheme is ColorScheme {
     colorScheme === ColorScheme.EmberDune ||
     colorScheme === ColorScheme.OceanGlow ||
     colorScheme === ColorScheme.DesertHaze ||
-    colorScheme === ColorScheme.DesertBloom ||
-    colorScheme === ColorScheme.SunnyCove ||
+    colorScheme === ColorScheme.ApricotBliss ||
     colorScheme === ColorScheme.System
   );
 }

--- a/src/hooks/useColorScheme.ts
+++ b/src/hooks/useColorScheme.ts
@@ -40,6 +40,7 @@ function validateColorScheme(colorScheme: string): colorScheme is ColorScheme {
     colorScheme === ColorScheme.OceanGlow ||
     colorScheme === ColorScheme.DesertHaze ||
     colorScheme === ColorScheme.DesertBloom ||
+    colorScheme === ColorScheme.SunnyCove ||
     colorScheme === ColorScheme.System
   );
 }


### PR DESCRIPTION
Adds a new **Sunny Cove** theme sourced from a [ColorHunt palette](https://colorhunt.co/palette/fffde8f7e0a3f09c674c8492/). The palette features cream white, golden yellow, coral orange, and muted teal. Updates `ColorScheme` enum, `themes` record, and `validateColorScheme` to register the new theme.