### PR TITLE
Add Sandy Shore theme, URL preview, and themes API

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,40 @@ This API provides access to a collection of quotes and authors.
 | `last_name`  | String | The last name of the author          |
 | `image_url`  | String | The URL of the author's image        |
 
+### 6. Create Theme
+
+**Endpoint:** `/api/themes`
+
+**Method:** `POST`
+
+**Body** (JSON)
+
+| Field        | Required | Description                                  |
+| ------------ | -------- | -------------------------------------------- |
+| `name`       | Yes      | Unique theme name (e.g. `sandy-shore`)       |
+| `background` | Yes      | 6-digit hex color, no `#` prefix             |
+| `accent`     | Yes      | 6-digit hex color, no `#` prefix             |
+| `primary`    | Yes      | 6-digit hex color, no `#` prefix             |
+| `secondary`  | Yes      | 6-digit hex color, no `#` prefix             |
+
+`likes` is always initialized to `0` for new themes and cannot be set via the API.
+
+**Example**
+
+```bash
+curl -X POST http://localhost:3000/api/themes \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "sandy-shore",
+    "background": "87aaaa",
+    "accent": "f6d7a7",
+    "primary": "f6eabe",
+    "secondary": "c8e3d4"
+  }'
+```
+
+**Response:** `201 Created` with the inserted theme. Validation failures return `400` with an `errors` array.
+
 ## Rate Limiting
 
 The API employs a sliding window rate limiting strategy, allowing 100 requests per minute per client.

--- a/migrations/insert-missing-themes.sql
+++ b/migrations/insert-missing-themes.sql
@@ -35,6 +35,7 @@ FROM (VALUES
   ('ember-dune',         0, '#bb6464', '#c3dbd9', '#cdb699', '#c8f2ef'),
   ('ocean-glow',         0, '#56a7a7', '#a0dbdb', '#fcea90', '#f9fbfc'),
   ('desert-haze',        0, '#f5e9d8', '#3e2c23', '#e76f2e', '#2fa4d7'),
-  ('apricot-bliss',      0, '#f09c67', '#f7e0a3', '#fffde8', '#4c8492')
+  ('apricot-bliss',      0, '#f09c67', '#f7e0a3', '#fffde8', '#4c8492'),
+  ('sandy-shore',        0, '#f6eabe', '#c8e3d4', '#87aaaa', '#f6d7a7')
 ) AS v(name, likes, background, accent, "primary", secondary)
 WHERE NOT EXISTS (SELECT 1 FROM themes WHERE themes.name = v.name);

--- a/migrations/insert-missing-themes.sql
+++ b/migrations/insert-missing-themes.sql
@@ -36,6 +36,6 @@ FROM (VALUES
   ('ocean-glow',         0, '#56a7a7', '#a0dbdb', '#fcea90', '#f9fbfc'),
   ('desert-haze',        0, '#f5e9d8', '#3e2c23', '#e76f2e', '#2fa4d7'),
   ('apricot-bliss',      0, '#f09c67', '#f7e0a3', '#fffde8', '#4c8492'),
-  ('sandy-shore',        0, '#f6eabe', '#c8e3d4', '#87aaaa', '#f6d7a7')
+  ('sandy-shore',        0, '#87aaaa', '#f6d7a7', '#f6eabe', '#c8e3d4')
 ) AS v(name, likes, background, accent, "primary", secondary)
 WHERE NOT EXISTS (SELECT 1 FROM themes WHERE themes.name = v.name);

--- a/src/app/api/themes/route.ts
+++ b/src/app/api/themes/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Database } from "@/utilities/database";
+
+const HEX_RE = /^[0-9a-fA-F]{6}$/;
+
+function validHex(value: unknown): value is string {
+  return typeof value === "string" && HEX_RE.test(value);
+}
+
+export async function GET() {
+  const db = new Database();
+  const themes = await db.findAllThemes();
+  return NextResponse.json({ results: themes });
+}
+
+export async function POST(request: NextRequest) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const { name, background, accent, primary, secondary, likes } = body as Record<string, unknown>;
+
+  const errors: string[] = [];
+  if (!name || typeof name !== "string") errors.push("name is required");
+  if (!validHex(background)) errors.push("background must be a 6-digit hex color (no #)");
+  if (!validHex(accent)) errors.push("accent must be a 6-digit hex color (no #)");
+  if (!validHex(primary)) errors.push("primary must be a 6-digit hex color (no #)");
+  if (!validHex(secondary)) errors.push("secondary must be a 6-digit hex color (no #)");
+  if (likes !== undefined && typeof likes !== "number") errors.push("likes must be a number");
+
+  if (errors.length > 0) return NextResponse.json({ errors }, { status: 400 });
+
+  const db = new Database();
+  const theme = await db.insertTheme({
+    name: name as string,
+    background: background as string,
+    accent: accent as string,
+    primary: primary as string,
+    secondary: secondary as string,
+    likes: typeof likes === "number" ? likes : 0,
+  });
+
+  return NextResponse.json(theme, { status: 201 });
+}

--- a/src/app/api/themes/route.ts
+++ b/src/app/api/themes/route.ts
@@ -21,7 +21,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
   }
 
-  const { name, background, accent, primary, secondary, likes } = body as Record<string, unknown>;
+  const { name, background, accent, primary, secondary } = body as Record<string, unknown>;
 
   const errors: string[] = [];
   if (!name || typeof name !== "string") errors.push("name is required");
@@ -29,7 +29,6 @@ export async function POST(request: NextRequest) {
   if (!validHex(accent)) errors.push("accent must be a 6-digit hex color (no #)");
   if (!validHex(primary)) errors.push("primary must be a 6-digit hex color (no #)");
   if (!validHex(secondary)) errors.push("secondary must be a 6-digit hex color (no #)");
-  if (likes !== undefined && typeof likes !== "number") errors.push("likes must be a number");
 
   if (errors.length > 0) return NextResponse.json({ errors }, { status: 400 });
 
@@ -40,7 +39,7 @@ export async function POST(request: NextRequest) {
     accent: accent as string,
     primary: primary as string,
     secondary: secondary as string,
-    likes: typeof likes === "number" ? likes : 0,
+    likes: 0,
   });
 
   return NextResponse.json(theme, { status: 201 });

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,6 +11,7 @@ import { Border } from "@/components/border";
 import { Settings } from "./settings";
 import { Feedback } from "./feedback";
 import { ThemeDebugPanel } from "@/components/themeDebugPanel";
+import { ThemePreview } from "@/components/themePreview";
 
 const crimson_text = Crimson_Text({
   subsets: ["latin"],
@@ -150,6 +151,7 @@ export default async function RootLayout({
           </Border>
         </main>
         <ThemeDebugPanel initialColorScheme={colorScheme} themes={themeRecord} />
+        <ThemePreview />
       </body>
     </html>
   );

--- a/src/components/themePreview.tsx
+++ b/src/components/themePreview.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { useEffect } from "react";
+import { Suspense } from "react";
+
+function ThemePreviewInjector() {
+  const params = useSearchParams();
+  const bg = params.get("bg");
+  const accent = params.get("accent");
+  const primary = params.get("primary");
+  const secondary = params.get("secondary");
+
+  const isPreview = bg && accent && primary && secondary;
+
+  useEffect(() => {
+    if (!isPreview) return;
+    const html = document.documentElement;
+    const original = html.getAttribute("data-theme");
+    html.setAttribute("data-theme", "preview");
+    return () => {
+      if (original) html.setAttribute("data-theme", original);
+      else html.removeAttribute("data-theme");
+    };
+  }, [isPreview]);
+
+  if (!isPreview) return null;
+
+  const css = `[data-theme="preview"]{--color-background:#${bg};--color-accent:#${accent};--color-primary:#${primary};--color-secondary:#${secondary};}`;
+  return <style dangerouslySetInnerHTML={{ __html: css }} />;
+}
+
+export function ThemePreview() {
+  return (
+    <Suspense>
+      <ThemePreviewInjector />
+    </Suspense>
+  );
+}

--- a/src/utilities/database.ts
+++ b/src/utilities/database.ts
@@ -193,6 +193,28 @@ export class Database {
       .execute();
   }
 
+  async insertTheme({
+    name,
+    background,
+    accent,
+    primary,
+    secondary,
+    likes = 0,
+  }: {
+    name: string;
+    background: string;
+    accent: string;
+    primary: string;
+    secondary: string;
+    likes?: number;
+  }) {
+    return this.connection
+      .insertInto("themes")
+      .values({ name, background, accent, primary, secondary, likes })
+      .returning(["id", "name", "background", "accent", "primary", "secondary", "likes"])
+      .executeTakeFirstOrThrow();
+  }
+
   async toggleLike({
     color_scheme,
     is_liked,


### PR DESCRIPTION
## Summary
- Add Sandy Shore theme (ColorHunt palette) via migration row and tuned colors
- Add `<ThemePreview>` client component that applies a `data-theme="preview"` style block driven by `?bg/&accent/&primary/&secondary` query params, no DB write
- Add `POST /api/themes` (with hex validation) plus `Database.insertTheme` for creating themes; `GET /api/themes` returns all themes

## Test plan
- [ ] Visit a URL with `?bg=...&accent=...&primary=...&secondary=...` and confirm preview applies and reverts on navigation
- [ ] `POST /api/themes` with valid hex values returns 201 and the new row; invalid hex returns 400
- [ ] Migration inserts `sandy-shore` only when missing