### PR TITLE
Sort themes by id

### DIFF
--- a/src/utilities/database.ts
+++ b/src/utilities/database.ts
@@ -189,7 +189,7 @@ export class Database {
     return this.connection
       .selectFrom("themes")
       .select(["id", "name", "background", "accent", "primary", "secondary", "likes"])
-      .orderBy("name", "asc")
+      .orderBy("id", "asc")
       .execute();
   }
 


### PR DESCRIPTION
## Summary
- `findAllThemes` now orders by `id ASC` instead of `name ASC`
- Affects `GET /api/themes` and the server-side themes loader

## Test plan
- [ ] `GET /api/themes` returns themes in insertion order
- [ ] Theme picker UI renders in id order