### PR TITLE
Add Brackets border style

### DIFF
--- a/migrations/migrate-border-to-border-style.sql
+++ b/migrations/migrate-border-to-border-style.sql
@@ -1,0 +1,17 @@
+-- Data migration: border (boolean) -> border_style (enum)
+-- Maps existing download_settings rows from setting='border' (value 'true'/'false')
+-- to setting='border_style' (value 'corners'/'none').
+-- Safe to re-run: only updates rows still keyed as 'border'.
+
+UPDATE download_settings AS d
+SET setting = 'border_style',
+    value = CASE WHEN d.value = 'true' THEN 'corners' ELSE 'none' END
+WHERE d.setting = 'border'
+  AND NOT EXISTS (
+    SELECT 1 FROM download_settings AS e
+    WHERE e.event_id = d.event_id AND e.setting = 'border_style'
+  );
+
+-- Drop any remaining legacy 'border' rows that couldn't migrate
+-- because a 'border_style' row already existed for the same event_id.
+DELETE FROM download_settings WHERE setting = 'border';

--- a/src/app/common.ts
+++ b/src/app/common.ts
@@ -4,6 +4,12 @@ export const SYSTEM_SCHEME = "system";
 export const DARK_SCHEME = "dark";
 export const LIGHT_SCHEME = "light";
 
+export enum BorderStyle {
+  Corners = "corners",
+  Brackets = "brackets",
+  None = "none",
+}
+
 export enum ImagePresets {
   Screen = "screen",
   InstagramSquare = "instagram-square",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,7 +5,7 @@ import { Partytown } from "@builder.io/partytown/react";
 
 import "./globals.css";
 import { Crimson_Text, EB_Garamond } from "next/font/google";
-import { ColorScheme, ImagePresets } from "@/app/common";
+import { BorderStyle, ColorScheme, ImagePresets } from "@/app/common";
 import { getThemes, generateThemeCSS, themesToRecord } from "@/app/themes";
 import { Border } from "@/components/border";
 import { Settings } from "./settings";
@@ -36,11 +36,10 @@ export const metadata = {
   },
 };
 const getCookieSettings = async () => {
-  let border = true;
-
   const cookieStore = await cookies();
-  const cookieBorder = cookieStore.get("border")?.value;
-  border = JSON.parse(cookieBorder ?? "true");
+
+  const borderStyle = (cookieStore.get("borderStyle")?.value ??
+    BorderStyle.Corners) as BorderStyle;
 
   const colorScheme = (cookieStore.get("colorScheme")?.value ??
     null) as ColorScheme | null;
@@ -57,7 +56,7 @@ const getCookieSettings = async () => {
     cookieStore.get("likedThemes")?.value ?? "{}"
   );
 
-  return { colorScheme, border, imagePreset, dimensions, likedThemes };
+  return { colorScheme, borderStyle, imagePreset, dimensions, likedThemes };
 };
 
 export default async function RootLayout({
@@ -70,7 +69,7 @@ export default async function RootLayout({
     getThemes(),
   ]);
 
-  const { border, colorScheme, imagePreset, likedThemes } = cookieValues;
+  const { borderStyle, colorScheme, imagePreset, likedThemes } = cookieValues;
   const themeRecord = themesToRecord(allThemes);
 
   return (
@@ -134,13 +133,13 @@ export default async function RootLayout({
         )}
       >
         <main className="flex min-h-screen flex-col p-4">
-          <Border enabled={border}>
+          <Border borderStyle={borderStyle}>
             <div className="flex w-full p-4 justify-between screenshot-hidden">
               <Feedback />
               <Settings
                 initialSettings={{
                   colorScheme,
-                  border,
+                  borderStyle,
                   imagePreset,
                   likedThemes,
                 }}

--- a/src/app/settings.tsx
+++ b/src/app/settings.tsx
@@ -4,7 +4,7 @@ import { ColorSchemeSelector } from "@/components/colorSchemeSelector";
 import { ImagePresetSelector } from "@/components/imagePresetSelector";
 import { BorderSelector } from "@/components/borderSelector";
 import { Cog6ToothIcon } from "@heroicons/react/24/outline";
-import { ImagePresets } from "@/app/common";
+import { BorderStyle, ImagePresets } from "@/app/common";
 import { ThemeColors } from "@/app/themes";
 import { useColorScheme } from "@/hooks/useColorScheme";
 import { updateSettings } from "./actions/updateSettings";
@@ -15,7 +15,7 @@ type SettingsProps = {
   initialSettings: {
     colorScheme: string | null;
     imagePreset: ImagePresets;
-    border: boolean;
+    borderStyle: BorderStyle;
     likedThemes: Record<string, boolean>;
   };
   themes: Record<string, ThemeColors>;
@@ -26,8 +26,8 @@ export function Settings({ initialSettings, themes }: SettingsProps) {
   const [imagePreset, setImagePreset] = React.useState<string>(
     initialSettings.imagePreset || ImagePresets.Screen
   );
-  const [border, setBorder] = React.useState<boolean>(
-    initialSettings.border ?? true
+  const [borderStyle, setBorderStyle] = React.useState<BorderStyle>(
+    initialSettings.borderStyle ?? BorderStyle.Corners
   );
   const validThemeNames = React.useMemo(
     () => new Set(Object.keys(themes)),
@@ -61,9 +61,9 @@ export function Settings({ initialSettings, themes }: SettingsProps) {
     }
     setImagePreset(value);
   };
-  const handleBorderChange = async (value: boolean) => {
-    await saveSettingChange({ field: "border", value });
-    setBorder(value);
+  const handleBorderStyleChange = async (value: BorderStyle) => {
+    await saveSettingChange({ field: "borderStyle", value });
+    setBorderStyle(value);
   };
 
   React.useEffect(() => {
@@ -108,7 +108,10 @@ export function Settings({ initialSettings, themes }: SettingsProps) {
             onChange={handleImagePresetChange}
           />
           <br />
-          <BorderSelector value={border} onChange={handleBorderChange} />
+          <BorderSelector
+            value={borderStyle}
+            onChange={handleBorderStyleChange}
+          />
         </div>
         <div className="mt-5 sm:mt-4 sm:flex sm:flex-row-reverse">
           <DownloadButton>Get Image</DownloadButton>

--- a/src/components/border.tsx
+++ b/src/components/border.tsx
@@ -1,4 +1,5 @@
 import clsx from "clsx";
+import { BorderStyle } from "@/app/common";
 
 const SCALE = 1;
 const cornerPosition = -2 * SCALE;
@@ -13,7 +14,7 @@ function Corner({ className }: { className: string }) {
         `border-${borderWidth}`,
         `w-${cornerDimension}`,
         `h-${cornerDimension}`,
-        className
+        className,
       )}
     >
       •
@@ -21,42 +22,98 @@ function Corner({ className }: { className: string }) {
   );
 }
 
-export function Border({
-  enabled,
-  children,
-}: {
-  enabled: boolean;
-  children: React.ReactNode;
-}) {
+function CornersBorder({ children }: { children: React.ReactNode }) {
   return (
     <div
-      className={`flex flex-col grow p-2 border-${
-        enabled ? borderWidth : 0
-      } border-primary rounded-md`}
+      className={`flex flex-col grow p-2 border-${borderWidth} border-primary rounded-md`}
     >
       <div
-        className={`relative flex flex-col grow h-full border-${
-          enabled ? borderWidth : 0
-        } border-primary rounded-md`}
+        className={`relative flex flex-col grow h-full border-${borderWidth} border-primary rounded-md`}
       >
         {children}
-        {enabled && (
-          <>
-            <Corner
-              className={`left-[-2px] top-[-2px] rounded-br-md rounded-tl-md`}
-            />
-            <Corner
-              className={`right-[-2px] top-[-2px] rounded-bl-md rounded-tr-md`}
-            />
-            <Corner
-              className={`left-[-2px] bottom-[-2px] rounded-tr-md rounded-bl-md`}
-            />
-            <Corner
-              className={`right-[-2px] bottom-[-2px] rounded-tl-md rounded-br-md`}
-            />
-          </>
-        )}
+        <Corner
+          className={`left-[-2px] top-[-2px] rounded-br-md rounded-tl-md`}
+        />
+        <Corner
+          className={`right-[-2px] top-[-2px] rounded-bl-md rounded-tr-md`}
+        />
+        <Corner
+          className={`left-[-2px] bottom-[-2px] rounded-tr-md rounded-bl-md`}
+        />
+        <Corner
+          className={`right-[-2px] bottom-[-2px] rounded-tl-md rounded-br-md`}
+        />
       </div>
     </div>
   );
+}
+
+function BracketCorner({ className }: { className: string }) {
+  return (
+    <svg
+      viewBox="0 0 25 25"
+      className={clsx("absolute w-6 h-6 text-primary z-10", className)}
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g
+        stroke="currentColor"
+        strokeWidth="1"
+        fill="none"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M0 24L14.9286 24L14.9286 6.77466L6.89005 6.77466" />
+        <path d="M24 0L24 14.9286L6.77472 14.9286L6.77472 6.89005" />
+      </g>
+    </svg>
+  );
+}
+
+function BracketsBorder({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col grow p-2 rounded-md">
+      <div className="relative flex flex-col grow h-full rounded-md">
+        <BracketCorner className="top-1 left-1" />
+        <BracketCorner className="top-1 right-1 rotate-90" />
+        <BracketCorner className="bottom-1 right-1 rotate-180" />
+        <BracketCorner className="bottom-1 left-1 -rotate-90" />
+
+        <div className="absolute top-[4px] left-7 right-7 h-px bg-primary" />
+        <div className="absolute bottom-[4px] left-7 right-7 h-px bg-primary" />
+        <div className="absolute left-[4px] top-7 bottom-7 w-px bg-primary" />
+        <div className="absolute right-[4px] top-7 bottom-7 w-px bg-primary" />
+
+        <div className="flex flex-col grow p-8">{children}</div>
+      </div>
+    </div>
+  );
+}
+
+function NoBorder({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col grow p-2 rounded-md">
+      <div className="relative flex flex-col grow h-full rounded-md">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export function Border({
+  borderStyle,
+  children,
+}: {
+  borderStyle: BorderStyle;
+  children: React.ReactNode;
+}) {
+  switch (borderStyle) {
+    case BorderStyle.Corners:
+      return <CornersBorder>{children}</CornersBorder>;
+    case BorderStyle.Brackets:
+      return <BracketsBorder>{children}</BracketsBorder>;
+    case BorderStyle.None:
+    default:
+      return <NoBorder>{children}</NoBorder>;
+  }
 }

--- a/src/components/borderSelector.tsx
+++ b/src/components/borderSelector.tsx
@@ -1,10 +1,17 @@
 import React from "react";
 import { DropdownSelector } from "@/components/dropdownSelector";
+import { BorderStyle } from "@/app/common";
 
 type BorderSelectorProps = {
-  value: boolean;
-  onChange: (value: boolean) => void;
+  value: BorderStyle;
+  onChange: (value: BorderStyle) => void;
 };
+
+const BORDER_STYLE_OPTIONS = [
+  { name: "Corners", value: BorderStyle.Corners },
+  { name: "Brackets", value: BorderStyle.Brackets },
+  { name: "None", value: BorderStyle.None },
+];
 
 export const BorderSelector: React.FC<BorderSelectorProps> = ({
   value,
@@ -12,16 +19,13 @@ export const BorderSelector: React.FC<BorderSelectorProps> = ({
 }) => {
   return (
     <>
-      <label htmlFor="border" className="text-primary">
-        Enable Border
+      <label htmlFor="borderStyle" className="text-primary">
+        Border Style
       </label>
       <DropdownSelector
-        options={[
-          { name: "Enabled", value: "true" },
-          { name: "Disabled", value: "false" },
-        ]}
-        value={value ? "true" : "false"}
-        onChange={(value: string) => onChange(value === "true")}
+        options={BORDER_STYLE_OPTIONS}
+        value={value}
+        onChange={(value: string) => onChange(value as BorderStyle)}
       />
     </>
   );

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,7 +4,7 @@ import { Ratelimit } from "@upstash/ratelimit";
 import { kv } from "@vercel/kv";
 import { Database } from "@/utilities/database";
 import type { NextFetchEvent, NextRequest } from "next/server";
-import { ImagePresets } from "@/app/common";
+import { BorderStyle, ImagePresets } from "@/app/common";
 import { imageDimensions } from "@/utilities/constants";
 
 const imageDimensionsMap = new Map(
@@ -53,7 +53,7 @@ async function imagePathHandler(request: NextRequest) {
   const quote_id = Number(request.nextUrl.pathname.split("/")[2]);
   const cookiesMap = new Map(cookies.map(({ name, value }) => [name, value]));
   const colorScheme = cookiesMap.get("colorScheme");
-  const border = cookiesMap.get("border") ?? "true";
+  const borderStyle = cookiesMap.get("borderStyle") ?? BorderStyle.Corners;
   const imagePreset = cookiesMap.get("imagePreset") ?? ImagePresets.Screen;
   let height = 1000;
   let width = 1000;
@@ -62,7 +62,7 @@ async function imagePathHandler(request: NextRequest) {
     quote_id,
     cookiesMap,
     colorScheme,
-    border,
+    borderStyle,
     imagePreset,
   });
   if (imageDimensionsMap.has(imagePreset)) {
@@ -97,7 +97,7 @@ async function imagePathHandler(request: NextRequest) {
   await new Database().saveDownloadSettings({
     quote_id,
     color_scheme: colorScheme,
-    border,
+    border_style: borderStyle,
     image_preset: imagePreset,
     width,
     height,

--- a/src/utilities/database.ts
+++ b/src/utilities/database.ts
@@ -235,14 +235,14 @@ export class Database {
   async saveDownloadSettings({
     quote_id,
     color_scheme,
-    border,
+    border_style,
     image_preset,
     width,
     height,
   }: {
     quote_id: number;
     color_scheme?: string;
-    border?: string;
+    border_style?: string;
     image_preset?: string;
     width?: number;
     height?: number;
@@ -251,7 +251,7 @@ export class Database {
 
     const settingsMap = {
       color_scheme,
-      border,
+      border_style,
       image_preset,
       width,
       height,


### PR DESCRIPTION
## Summary
- Replace boolean `border` field with `BorderStyle` enum (`Corners` | `Brackets` | `None`)
- Add new **Brackets** style: L-shaped viewfinder corners with crop-mark tick lines
- Rename DB column `border` → `border_style`
- `BorderSelector` becomes a 3-option dropdown

## Test plan
- [ ] Verify each border style renders correctly on the snapshot preview
- [ ] Existing snapshots with `border` boolean still load
- [ ] Settings dropdown selects/persists all three values