### PR TITLE
Add Art Deco border style

### DIFF
--- a/src/app/common.ts
+++ b/src/app/common.ts
@@ -9,6 +9,7 @@ export enum BorderStyle {
   Brackets = "brackets",
   Diamonds = "diamonds",
   Sparkles = "sparkles",
+  ArtDeco = "art-deco",
   None = "none",
 }
 

--- a/src/components/border.tsx
+++ b/src/components/border.tsx
@@ -3,6 +3,7 @@ import { CornersBorder } from "@/components/borders/Corners";
 import { BracketsBorder } from "@/components/borders/Brackets";
 import { DiamondsBorder } from "@/components/borders/Diamonds";
 import { SparklesBorder } from "@/components/borders/Sparkles";
+import { ArtDecoBorder } from "@/components/borders/ArtDeco";
 import { NoBorder } from "@/components/borders/None";
 
 export function Border({
@@ -21,6 +22,8 @@ export function Border({
       return <DiamondsBorder>{children}</DiamondsBorder>;
     case BorderStyle.Sparkles:
       return <SparklesBorder>{children}</SparklesBorder>;
+    case BorderStyle.ArtDeco:
+      return <ArtDecoBorder>{children}</ArtDecoBorder>;
     case BorderStyle.None:
     default:
       return <NoBorder>{children}</NoBorder>;

--- a/src/components/borderSelector.tsx
+++ b/src/components/borderSelector.tsx
@@ -12,6 +12,7 @@ const BORDER_STYLE_OPTIONS = [
   { name: "Brackets", value: BorderStyle.Brackets },
   { name: "Diamonds", value: BorderStyle.Diamonds },
   { name: "Sparkles", value: BorderStyle.Sparkles },
+  { name: "Art Deco", value: BorderStyle.ArtDeco },
   { name: "None", value: BorderStyle.None },
 ];
 

--- a/src/components/borders/ArtDeco.tsx
+++ b/src/components/borders/ArtDeco.tsx
@@ -1,0 +1,45 @@
+import clsx from "clsx";
+
+function ArtDecoCorner({ className }: { className: string }) {
+  return (
+    <svg
+      viewBox="0 0 32 32"
+      className={clsx("absolute w-8 h-8 text-primary z-10", className)}
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g
+        stroke="currentColor"
+        strokeWidth="1"
+        fill="none"
+        strokeLinecap="square"
+        strokeLinejoin="miter"
+      >
+        <rect x="2" y="2" width="5" height="5" />
+        <path d="M14 0 L32 0" />
+        <path d="M0 14 L0 32" />
+        <path d="M14 0 L14 10 L10 10 L10 14 L0 14" />
+      </g>
+    </svg>
+  );
+}
+
+export function ArtDecoBorder({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col grow p-2 rounded-md">
+      <div className="relative flex flex-col grow h-full rounded-md">
+        <ArtDecoCorner className="top-1 left-1" />
+        <ArtDecoCorner className="top-1 right-1 rotate-90" />
+        <ArtDecoCorner className="bottom-1 right-1 rotate-180" />
+        <ArtDecoCorner className="bottom-1 left-1 -rotate-90" />
+
+        <div className="absolute top-[4px] left-9 right-9 h-px bg-primary" />
+        <div className="absolute bottom-[4px] left-9 right-9 h-px bg-primary" />
+        <div className="absolute left-[4px] top-9 bottom-9 w-px bg-primary" />
+        <div className="absolute right-[4px] top-9 bottom-9 w-px bg-primary" />
+
+        <div className="flex flex-col grow p-8">{children}</div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `ArtDeco` variant to `BorderStyle` enum and wires it into the `Border` switch + dropdown selector
- New `ArtDecoBorder` wrapper in `src/components/borders/ArtDeco.tsx` matching the existing per-corner SVG + edge-line pattern used by Brackets/Diamonds/Sparkles
- Corner geometry: small accent square at each outer corner with a stepped L meeting the edge lines; uses `text-primary` / `bg-primary` so it inherits theme colors instead of the hardcoded HSL from the source snippet

## Test plan
- [ ] Open the app, pick each theme, switch border style to "Art Deco" — corners render, edge lines connect cleanly to the stepped corners
- [ ] Verify the four other border styles still render unchanged
- [ ] Export an image with Art Deco selected and confirm the border survives the snapshot pipeline