### PR TITLE
feat: password-protected theme creation page

### DIFF
--- a/migrations/insert-missing-themes.sql
+++ b/migrations/insert-missing-themes.sql
@@ -36,6 +36,7 @@ FROM (VALUES
   ('ocean-glow',         0, '#56a7a7', '#a0dbdb', '#fcea90', '#f9fbfc'),
   ('desert-haze',        0, '#f5e9d8', '#3e2c23', '#e76f2e', '#2fa4d7'),
   ('apricot-bliss',      0, '#f09c67', '#f7e0a3', '#fffde8', '#4c8492'),
-  ('sandy-shore',        0, '#87aaaa', '#f6d7a7', '#f6eabe', '#c8e3d4')
+  ('sandy-shore',        0, '#87aaaa', '#f6d7a7', '#f6eabe', '#c8e3d4'),
+  ('iris-cream',         0, '#fff5de', '#c6b4ce', '#3c5186', '#9b72aa')
 ) AS v(name, likes, background, accent, "primary", secondary)
 WHERE NOT EXISTS (SELECT 1 FROM themes WHERE themes.name = v.name);

--- a/src/app/actions/adminLogin.ts
+++ b/src/app/actions/adminLogin.ts
@@ -1,0 +1,33 @@
+"use server";
+
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import {
+  ADMIN_COOKIE,
+  expectedToken,
+  verifyPassword,
+} from "@/utilities/admin-auth";
+
+const SAFE_FROM = /^\/themes(\/|$)/;
+
+export async function adminLogin(formData: FormData) {
+  const password = String(formData.get("password") ?? "");
+  const fromParamRaw = String(formData.get("from") ?? "");
+  const from = SAFE_FROM.test(fromParamRaw) ? fromParamRaw : "/themes/new";
+
+  if (!verifyPassword(password)) {
+    redirect(`/themes/login?error=1&from=${encodeURIComponent(from)}`);
+  }
+
+  const token = await expectedToken();
+  const store = await cookies();
+  store.set(ADMIN_COOKIE, token!, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: 60 * 60 * 24 * 7, // 7 days
+  });
+
+  redirect(from);
+}

--- a/src/app/themes/login/page.tsx
+++ b/src/app/themes/login/page.tsx
@@ -1,0 +1,50 @@
+import { adminLogin } from "@/app/actions/adminLogin";
+
+export const metadata = {
+  title: "Admin — Stoic Snapshots",
+};
+
+export default async function AdminLoginPage(props: {
+  searchParams: Promise<{ from?: string; error?: string }>;
+}) {
+  const { from, error } = await props.searchParams;
+
+  return (
+    <div className="w-full max-w-sm px-4 py-12">
+      <h1 className="text-2xl font-semibold text-primary mb-1">Admin access</h1>
+      <p className="text-secondary mb-6">
+        Enter the admin password to manage themes.
+      </p>
+
+      <form action={adminLogin}>
+        <input type="hidden" name="from" value={from ?? "/themes/new"} />
+
+        <label
+          htmlFor="password"
+          className="block text-sm font-medium text-primary mb-1"
+        >
+          Admin password
+        </label>
+        <input
+          id="password"
+          name="password"
+          type="password"
+          autoFocus
+          required
+          className="focus:ring-primary focus:border-primary block w-full shadow-xs sm:text-sm border-primary rounded-md"
+        />
+
+        {error && (
+          <p className="mt-2 text-sm text-secondary">Incorrect password.</p>
+        )}
+
+        <button
+          type="submit"
+          className="mt-5 inline-flex justify-center rounded-md bg-background px-4 py-2 text-sm font-semibold text-primary hover:text-background hover:bg-primary border border-primary"
+        >
+          Unlock
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/app/themes/new/page.tsx
+++ b/src/app/themes/new/page.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import * as React from "react";
+import { Suspense } from "react";
+import { useSearchParams } from "next/navigation";
+import { Loader } from "@/components/loader";
+
+type Role = "background" | "accent" | "primary" | "secondary";
+
+const ROLES: { key: Role; label: string; hint: string }[] = [
+  { key: "background", label: "Background", hint: "Page background" },
+  { key: "accent", label: "Accent", hint: "Cards & secondary surfaces" },
+  { key: "primary", label: "Primary", hint: "Main text / foreground" },
+  { key: "secondary", label: "Secondary", hint: "Highlights & buttons" },
+];
+
+const DEFAULTS: Record<Role, string> = {
+  background: "#fff5de",
+  accent: "#c6b4ce",
+  primary: "#3c5186",
+  secondary: "#9b72aa",
+};
+
+const HEX_RE = /^#?[0-9a-fA-F]{6}$/;
+
+function normalizeHex(value: string): string {
+  const v = value.trim();
+  return v.startsWith("#") ? v : `#${v}`;
+}
+
+function AddThemeForm() {
+  const params = useSearchParams();
+
+  const [name, setName] = React.useState(params.get("name") ?? "");
+  const [colors, setColors] = React.useState<Record<Role, string>>(() => ({
+    background: normalizeHex(params.get("bg") ?? DEFAULTS.background),
+    accent: normalizeHex(params.get("accent") ?? DEFAULTS.accent),
+    primary: normalizeHex(params.get("primary") ?? DEFAULTS.primary),
+    secondary: normalizeHex(params.get("secondary") ?? DEFAULTS.secondary),
+  }));
+
+  const [isPending, startTransition] = React.useTransition();
+  const [result, setResult] = React.useState<
+    { type: "success"; name: string } | { type: "error"; messages: string[] } | null
+  >(null);
+
+  const setColor = (role: Role, value: string) =>
+    setColors((prev) => ({ ...prev, [role]: value }));
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    const errors: string[] = [];
+    if (!name.trim()) errors.push("Name is required");
+    for (const { key, label } of ROLES) {
+      if (!HEX_RE.test(colors[key])) {
+        errors.push(`${label} must be a 6-digit hex color`);
+      }
+    }
+    if (errors.length > 0) {
+      setResult({ type: "error", messages: errors });
+      return;
+    }
+
+    setResult(null);
+    startTransition(async () => {
+      try {
+        const res = await fetch("/api/themes", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: name.trim().toLowerCase().replace(/\s+/g, "-"),
+            background: colors.background.replace("#", ""),
+            accent: colors.accent.replace("#", ""),
+            primary: colors.primary.replace("#", ""),
+            secondary: colors.secondary.replace("#", ""),
+          }),
+        });
+
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({}));
+          const messages: string[] = data.errors ??
+            (data.error ? [data.error] : ["Something went wrong"]);
+          setResult({ type: "error", messages });
+          return;
+        }
+
+        const theme = await res.json();
+        setResult({ type: "success", name: theme.name });
+      } catch {
+        setResult({ type: "error", messages: ["Network error — please try again"] });
+      }
+    });
+  };
+
+  return (
+    <div className="w-full max-w-2xl px-4 py-8">
+      <h1 className="text-3xl font-semibold text-primary mb-1">Add a Theme</h1>
+      <p className="text-secondary mb-8">
+        Pick four colors, name it, and save it to the theme library.
+      </p>
+
+      {/* Live preview */}
+      <div
+        className="rounded-lg border border-primary overflow-hidden mb-8"
+        style={{ backgroundColor: colors.background }}
+      >
+        <div className="p-6">
+          <div
+            className="rounded-md p-4 mb-4"
+            style={{ backgroundColor: colors.accent }}
+          >
+            <p
+              className="text-lg font-semibold"
+              style={{ color: colors.primary }}
+            >
+              The happiness of your life depends upon the quality of your
+              thoughts.
+            </p>
+          </div>
+          <div className="flex items-center justify-between">
+            <span style={{ color: colors.primary }}>— Marcus Aurelius</span>
+            <span
+              className="rounded-md px-3 py-1 text-sm font-semibold"
+              style={{ backgroundColor: colors.secondary, color: colors.background }}
+            >
+              {name.trim() || "Preview"}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <form onSubmit={handleSubmit}>
+        <div className="mb-6">
+          <label
+            htmlFor="theme-name"
+            className="block text-sm font-medium text-primary mb-1"
+          >
+            Theme name
+          </label>
+          <input
+            id="theme-name"
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Iris Cream"
+            className="focus:ring-primary focus:border-primary block w-full shadow-xs sm:text-sm border-primary rounded-md"
+          />
+          <p className="text-xs text-secondary mt-1">
+            Saved as <code>{name.trim().toLowerCase().replace(/\s+/g, "-") || "iris-cream"}</code>
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-8">
+          {ROLES.map(({ key, label, hint }) => (
+            <div key={key}>
+              <label
+                htmlFor={`color-${key}`}
+                className="block text-sm font-medium text-primary"
+              >
+                {label}
+              </label>
+              <p className="text-xs text-secondary mb-1">{hint}</p>
+              <div className="flex items-center gap-2">
+                <input
+                  id={`color-${key}`}
+                  type="color"
+                  value={HEX_RE.test(colors[key]) ? normalizeHex(colors[key]) : "#000000"}
+                  onChange={(e) => setColor(key, e.target.value)}
+                  className="h-10 w-12 shrink-0 cursor-pointer rounded-md border border-primary bg-transparent p-0.5"
+                  aria-label={`${label} color picker`}
+                />
+                <input
+                  type="text"
+                  value={colors[key]}
+                  onChange={(e) => setColor(key, normalizeHex(e.target.value))}
+                  placeholder="#000000"
+                  className="focus:ring-primary focus:border-primary block w-full shadow-xs sm:text-sm border-primary rounded-md font-mono"
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {result?.type === "error" && (
+          <ul className="mb-4 list-disc list-inside text-sm text-secondary">
+            {result.messages.map((m) => (
+              <li key={m}>{m}</li>
+            ))}
+          </ul>
+        )}
+
+        {result?.type === "success" && (
+          <p className="mb-4 text-sm font-semibold text-primary">
+            Saved “{result.name}”! It’s now available in the theme picker.
+          </p>
+        )}
+
+        <button
+          type="submit"
+          disabled={isPending}
+          className="inline-flex justify-center rounded-md bg-background px-4 py-2 text-sm font-semibold text-primary hover:text-background hover:bg-primary border border-primary disabled:cursor-not-allowed disabled:text-background disabled:bg-primary"
+        >
+          {isPending ? <Loader /> : "Save theme"}
+        </button>
+      </form>
+    </div>
+  );
+}
+
+export default function AddThemePage() {
+  return (
+    <Suspense fallback={<Loader />}>
+      <AddThemeForm />
+    </Suspense>
+  );
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ADMIN_COOKIE, verifyToken } from "@/utilities/admin-auth";
+
+export async function middleware(req: NextRequest) {
+  const isApi = req.nextUrl.pathname.startsWith("/api/themes");
+
+  // Only writes to the themes API are protected; reads (GET) stay public so
+  // the app can render the theme list.
+  if (isApi && req.method !== "POST") {
+    return NextResponse.next();
+  }
+
+  const token = req.cookies.get(ADMIN_COOKIE)?.value;
+  if (await verifyToken(token)) {
+    return NextResponse.next();
+  }
+
+  if (isApi) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const url = req.nextUrl.clone();
+  url.pathname = "/themes/login";
+  url.search = `?from=${encodeURIComponent(req.nextUrl.pathname)}`;
+  return NextResponse.redirect(url);
+}
+
+export const config = {
+  matcher: ["/themes/new", "/themes/new/:path*", "/api/themes"],
+};

--- a/src/utilities/admin-auth.ts
+++ b/src/utilities/admin-auth.ts
@@ -1,0 +1,45 @@
+export const ADMIN_COOKIE = "admin_session";
+
+async function sha256Hex(input: string): Promise<string> {
+  const data = new TextEncoder().encode(input);
+  const digest = await crypto.subtle.digest("SHA-256", data);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+// Constant-time string comparison to avoid leaking length/content via timing.
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let mismatch = 0;
+  for (let i = 0; i < a.length; i++) {
+    mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return mismatch === 0;
+}
+
+// The cookie value is a hash of the password (+ optional ADMIN_SECRET salt),
+// never the password itself.
+export async function computeToken(password: string): Promise<string> {
+  const secret = process.env.ADMIN_SECRET ?? "";
+  return sha256Hex(`${password}:${secret}`);
+}
+
+export async function expectedToken(): Promise<string | null> {
+  const password = process.env.ADMIN_PASSWORD;
+  if (!password) return null;
+  return computeToken(password);
+}
+
+export async function verifyToken(token: string | undefined): Promise<boolean> {
+  if (!token) return false;
+  const expected = await expectedToken();
+  if (!expected) return false;
+  return timingSafeEqual(token, expected);
+}
+
+export function verifyPassword(password: string): boolean {
+  const expected = process.env.ADMIN_PASSWORD;
+  if (!expected) return false;
+  return timingSafeEqual(password, expected);
+}


### PR DESCRIPTION
## Summary

Adds a self-service page at **`/themes/new`** for adding themes to the DB-backed theme library, gated behind a shared admin password.

Previously the only way to add a theme was hand-editing `migrations/insert-missing-themes.sql` and running it against Postgres. This adds a UI flow plus the seed entry for `iris-cream`.

## What's included

**Theme page** — `src/app/themes/new/page.tsx`
- Name field (auto-slugified to kebab-case, shown live)
- Four color inputs (background / accent / primary / secondary) — native picker + hex text box, kept in sync
- Live preview card rendering a real quote with the chosen colors
- Client + server validation (6-digit hex); strips `#` before POST
- Pre-fills from query params: `/themes/new?name=Iris%20Cream&bg=fff5de&accent=c6b4ce&primary=3c5186&secondary=9b72aa`
- Submits to the existing `POST /api/themes` endpoint

**Auth gate**
- `src/middleware.ts` — protects `/themes/new` (+ subpaths) and `POST /api/themes`. Unauthenticated page loads redirect to `/themes/login`; unauthenticated API writes get `401`. `GET /api/themes` stays public so the app can render themes.
- `src/utilities/admin-auth.ts` — cookie holds `sha256(password + ADMIN_SECRET)`, never the password; constant-time comparison.
- `src/app/themes/login/page.tsx` + `src/app/actions/adminLogin.ts` — password form; on success sets `admin_session` cookie (httpOnly, secure in prod, sameSite=lax, 7-day expiry). Open-redirect guarded (`/themes/*` only).

**Seed** — adds `iris-cream` to `migrations/insert-missing-themes.sql` (idempotent `WHERE NOT EXISTS`).

## ⚠️ Required config

Set these env vars (otherwise auth always fails by design):

\`\`\`bash
ADMIN_PASSWORD=your-strong-password
ADMIN_SECRET=some-random-string   # optional salt; recommended
\`\`\`

## Test plan

- [ ] Visit `/themes/new` unauthenticated → redirected to `/themes/login`
- [ ] Wrong password → "Incorrect password"; correct password → redirected back to the form
- [ ] Add a theme → appears in the theme picker
- [ ] `POST /api/themes` without the cookie → `401`; `GET /api/themes` → still works